### PR TITLE
change api to allow creating the options through the main class

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Node client library to generate urls for
 ## Usage
 
 ```ts
-import Imgproxy, { ImgproxyOptions, Gravity } from 'imgproxy';
+import Imgproxy, { Gravity } from 'imgproxy';
 
 const imgproxy = new Imgproxy({
   baseUrl: 'https://imgproxy.example.com',
@@ -15,13 +15,12 @@ const imgproxy = new Imgproxy({
   encode: true,
 });
 
-// ...
-
-const options = new ImgproxyOptions()
+imgproxy
+  .builder()
   .resize('fill', 300, 200, 0)
   .gravity(Gravity.north_east)
-  .dpr(2);
-imgproxy.generateUrl('https://example.com/path/to/image.jpg', options);
+  .dpr(2)
+  .generateUrl('https://example.com/path/to/image.jpg');
 ```
 
 ## Contributing

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,56 +1,10 @@
-import * as crypto from 'crypto';
-import * as urljoin from 'url-join';
-
-import ImgproxyOptions from './options';
-import { Gravity, WatermarkPosition } from './types';
-
-const hexDecode = (hex: string) => Buffer.from(hex, 'hex');
-
-const urlSafeEncode = (data: any) =>
-  Buffer.from(data, 'utf8')
-    .toString('base64')
-    .replace(/=/g, '')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_');
-
-const sign = (key: string, salt: string, target: string) => {
-  const hmac = crypto.createHmac('sha256', hexDecode(key));
-  hmac.update(hexDecode(salt));
-  hmac.update(target);
-  return urlSafeEncode(hmac.digest());
-};
-
-interface ImgproxyConfig {
-  /**
-   * The url where imgproxy runs.
-   */
-  baseUrl: string;
-  /**
-   * If urls should be encoded with base64.
-   */
-  encode?: boolean;
-  /**
-   * If insecure usage is supported by the service, true by default.
-   * When set to a string it will be used as the plain "signature".
-   */
-  insecure?: boolean | string;
-}
-
-interface ImgproxySecureConfig extends ImgproxyConfig {
-  /**
-   * The key to use for creating the signature.
-   */
-  key: string;
-  /**
-   * The salt to use for creating the signature.
-   */
-  salt: string;
-  insecure: false;
-}
-
-const isSecureConfig = (config: any): config is ImgproxySecureConfig => {
-  return 'key' in config && 'salt' in config;
-};
+import { ImgproxyBuilder } from './builder';
+import {
+  Gravity,
+  ImgproxyConfig,
+  ImgproxySecureConfig,
+  WatermarkPosition,
+} from './types';
 
 export default class Imgproxy {
   private config: ImgproxyConfig | ImgproxySecureConfig;
@@ -59,32 +13,9 @@ export default class Imgproxy {
     this.config = config;
   }
 
-  /**
-   * Generates a URL using the given the options.
-   *
-   * @param uri The uri of the image
-   * @param options an options object
-   * @param extension optional string to append as extension
-   */
-  public generateUrl(
-    uri: string,
-    options: ImgproxyOptions,
-    extension?: string
-  ) {
-    const serializedOptions = options.serialize();
-    const config = this.config;
-
-    uri = config.encode !== false ? urlSafeEncode(uri) : uri;
-    uri = extension ? `${uri}.${extension}` : uri;
-    uri = `/${serializedOptions}/${uri}`;
-
-    const signature = isSecureConfig(config)
-      ? sign(config.key, config.salt, uri)
-      : typeof config.insecure === 'string'
-      ? config.insecure
-      : 'insecure';
-    return urljoin(config.baseUrl, `${signature}${uri}`);
+  public builder() {
+    return new ImgproxyBuilder(this.config);
   }
 }
 
-export { ImgproxyOptions, Gravity, WatermarkPosition };
+export { Gravity, WatermarkPosition };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,31 @@
+export interface ImgproxyConfig {
+  /**
+   * The url where imgproxy runs.
+   */
+  baseUrl: string;
+  /**
+   * If urls should be encoded with base64.
+   */
+  encode?: boolean;
+  /**
+   * If insecure usage is supported by the service, true by default.
+   * When set to a string it will be used as the plain "signature".
+   */
+  insecure?: boolean | string;
+}
+
+export interface ImgproxySecureConfig extends ImgproxyConfig {
+  /**
+   * The key to use for creating the signature.
+   */
+  key: string;
+  /**
+   * The salt to use for creating the signature.
+   */
+  salt: string;
+  insecure: false;
+}
+
 export type ResizingType = 'fit' | 'fill' | 'crop';
 
 export type HexColor = string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,30 @@
+import crypto from 'crypto';
+import { FocusPoint, ImgproxySecureConfig, RGBColor } from './types';
+
+export const isRGBColor = (obj: any): obj is RGBColor => {
+  return 'r' in obj && 'g' in obj && 'b' in obj;
+};
+
+export const isFocusPoint = (obj: any): obj is FocusPoint => {
+  return 'x' in obj && 'y' in obj;
+};
+
+export const isSecureConfig = (config: any): config is ImgproxySecureConfig => {
+  return 'key' in config && 'salt' in config;
+};
+
+const hexDecode = (hex: string) => Buffer.from(hex, 'hex');
+
+export const urlSafeEncode = (data: any) =>
+  Buffer.from(data, 'utf8')
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+
+export const sign = (key: string, salt: string, target: string) => {
+  const hmac = crypto.createHmac('sha256', hexDecode(key));
+  hmac.update(hexDecode(salt));
+  hmac.update(target);
+  return urlSafeEncode(hmac.digest());
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "lib": ["esnext"],
     "noUnusedLocals": true,
     "noImplicitAny": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "esModuleInterop": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
This would allow generating a url in a more streamlined API;

<!--
```ts
const imgproxy = new Imgproxy({
  // ... configuration
});

// ...

const defaultImgproxy = () => imgproxy.reset().dpr(headers.dpr || 1);

// ...

defaultImgproxy().height(100).generateUrl('hello.png');
-->

```ts
const imgproxy = new Imgproxy({
  baseUrl: 'https://imgproxy.example.com',
  key: process.env.IMGPROXY_KEY,
  salt: process.env.IMGPROXY_SALT,
  encode: true,
})

// ...

imgproxy
  .builder()
  .resize('fill', 300, 200, 0)
  .gravity(Gravity.north_east)
  .dpr(2)
  .generateUrl('https://example.com/path/to/image.jpg');