### PR TITLE
make signature size configurable

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -153,7 +153,7 @@ export class ImgproxyBuilder {
     uri = `/${options}/${uri}`;
 
     const signature = isSecureConfig(config)
-      ? sign(config.key, config.salt, uri)
+      ? sign(config.key, config.salt, uri, config.signatureSize || 32)
       : typeof config.insecure === 'string'
       ? config.insecure
       : 'insecure';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,19 @@ import {
   ImgproxySecureConfig,
   WatermarkPosition,
 } from './types';
+import { isSecureConfig } from './utils';
 
 export default class Imgproxy {
   private config: ImgproxyConfig | ImgproxySecureConfig;
 
   constructor(config: ImgproxyConfig | ImgproxySecureConfig) {
+    if (isSecureConfig(config) && typeof config.signatureSize !== 'undefined') {
+      if (config.signatureSize < 1 || config.signatureSize > 32) {
+        throw new Error(
+          '`signatureSize` must be greater than or equal to 1, and less than or equal to 32'
+        );
+      }
+    }
     this.config = config;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,8 +23,20 @@ export interface ImgproxySecureConfig extends ImgproxyConfig {
    * The salt to use for creating the signature.
    */
   salt: string;
+  /**
+   * Number of bytes to use for signature before encoding to Base64. Default: 32
+   */
+  signatureSize?: SignatureSize;
+
   insecure: false;
 }
+
+// prettier-ignore
+export type SignatureSize =
+  | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8
+  | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16
+  | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24
+  | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 32;
 
 export type ResizingType = 'fit' | 'fill' | 'crop';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,9 +22,14 @@ export const urlSafeEncode = (data: any) =>
     .replace(/\+/g, '-')
     .replace(/\//g, '_');
 
-export const sign = (key: string, salt: string, target: string) => {
+export const sign = (
+  key: string,
+  salt: string,
+  target: string,
+  size: number = 32
+) => {
   const hmac = crypto.createHmac('sha256', hexDecode(key));
   hmac.update(hexDecode(salt));
   hmac.update(target);
-  return urlSafeEncode(hmac.digest());
+  return urlSafeEncode(hmac.digest().slice(0, size));
 };

--- a/tslint.json
+++ b/tslint.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["tslint:latest", "tslint-config-prettier"]  
+  "extends": ["tslint:latest", "tslint-config-prettier"],
+  "rules": {
+    "interface-name" : [true, "never-prefix"]
+  }
 }


### PR DESCRIPTION
this matches with the [IMGPROXY_SIGNATURE_SIZE](https://github.com/imgproxy/imgproxy/blob/e071396fd6b186a83271034586399f9725abcf6c/docs/configuration.md#url-signature) server config option

fixes #1