### PR TITLE
feat(builder): return `this` from `setOption` and `clearOption`

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -134,10 +134,12 @@ export class ImgproxyBuilder extends BaseBuilder {
 
   public setOption(option: string, value: string) {
     this.options[option] = value;
+    return this;
   }
 
   public clearOption(option: string) {
     this.options[option] = undefined;
+    return this;
   }
 
   protected serializeOptions() {


### PR DESCRIPTION
Currently, `setOption` can't be used as an alternative for missing options in the `Builder` class due to not returning any value. By returning `this`, we can use `setOption` in the same way as `format`, `resize`, etc, and keep the API consistent and predictable.

Before
---

```typescript
const builder = imgproxy.builder();
builder.setOption('expires', (Date.now() / 1000 + 60).toFixed(0)); // 1 minute expiry

return builder
  .format('jpg')
  .resize('fit', 1920, 1080, false)
  .generateUrl('...');
```

After
---

```typescript
return imgproxy
  .builder()
  .format('jpg')
  .resize('fit', 1920, 1080, false)
  .setOption('expires', (Date.now() / 1000 + 60).toFixed(0)), // 1 minute expiry
  .generateUrl('...');
```