### PR TITLE
add Imgproxy as a named export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.4.1
+
+- Add a named export for `Imgproxy` in addition to `default`, so you can use it
+  like `import { Imgproxy } from "imgproxy";`. This is necessary if the tsconfig
+  is set to `"module": "Node16"`.
+
 # v1.3.1
 
 - Export all files from `dist/` in package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
   like `import { Imgproxy } from "imgproxy";`. This is necessary if the tsconfig
   is set to `"module": "Node16"`.
 
+# v1.4.0
+
+- Add `minWidth`, `minHeight`, `maxBytes`, and `expires` methods to
+  `ImgproxyBuilder`.
+
 # v1.3.1
 
 - Export all files from `dist/` in package.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imgproxy",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "NodeJS client library to generate imgproxy urls",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,4 +31,10 @@ export default class Imgproxy {
   }
 }
 
-export { Gravity, WatermarkPosition, ImgproxyConfig, ImgproxySecureConfig };
+export {
+  Imgproxy,
+  Gravity,
+  WatermarkPosition,
+  ImgproxyConfig,
+  ImgproxySecureConfig,
+};


### PR DESCRIPTION
Because we use `"module": "Node16"` in our tsconfig importing classes that are exported as `export { Imgproxy as default }` doesn't work. For that we need a named export.